### PR TITLE
Custom endpoint spinner when App ID is `null` and `res/raw/layer_endpoints` exists

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+src/providerrails/res/raw/

--- a/app/src/main/java/com/layer/messenger/App.java
+++ b/app/src/main/java/com/layer/messenger/App.java
@@ -50,6 +50,13 @@ public class App extends Application {
     public void onCreate() {
         super.onCreate();
 
+        // Enable verbose logging in debug builds
+        if (BuildConfig.DEBUG) {
+            com.layer.atlas.util.Log.setAlwaysLoggable(true);
+            com.layer.messenger.util.Log.setAlwaysLoggable(true);
+            LayerClient.setLoggingEnabled(this, true);
+        }
+
         // Allow the LayerClient to track app state
         LayerClient.applicationCreated(this);
 

--- a/app/src/main/java/com/layer/messenger/PushNotificationReceiver.java
+++ b/app/src/main/java/com/layer/messenger/PushNotificationReceiver.java
@@ -11,10 +11,6 @@ import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 
 import com.layer.atlas.util.Util;
-import com.layer.messenger.App;
-import com.layer.messenger.BuildConfig;
-import com.layer.messenger.MessagesListActivity;
-import com.layer.messenger.R;
 import com.layer.messenger.util.Log;
 import com.layer.sdk.LayerClient;
 import com.layer.sdk.messaging.Conversation;

--- a/app/src/providerdemo/java/com/layer/messenger/flavor/DemoAtlasIdScannerActivity.java
+++ b/app/src/providerdemo/java/com/layer/messenger/flavor/DemoAtlasIdScannerActivity.java
@@ -6,8 +6,8 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
 import com.google.android.gms.common.GoogleApiAvailability;
-import com.layer.messenger.util.Log;
 import com.layer.messenger.R;
+import com.layer.messenger.util.Log;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/app/src/providerdemo/java/com/layer/messenger/flavor/DemoLoginActivity.java
+++ b/app/src/providerdemo/java/com/layer/messenger/flavor/DemoLoginActivity.java
@@ -12,10 +12,10 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.layer.messenger.App;
-import com.layer.messenger.util.AuthenticationProvider;
 import com.layer.messenger.ConversationsListActivity;
-import com.layer.messenger.util.Log;
 import com.layer.messenger.R;
+import com.layer.messenger.util.AuthenticationProvider;
+import com.layer.messenger.util.Log;
 
 public class DemoLoginActivity extends AppCompatActivity {
     EditText mName;

--- a/app/src/providerdemo/java/com/layer/messenger/flavor/Flavor.java
+++ b/app/src/providerdemo/java/com/layer/messenger/flavor/Flavor.java
@@ -11,7 +11,7 @@ import com.layer.sdk.LayerClient;
 public class Flavor implements App.Flavor {
     // Set your Layer App ID from your Layer developer dashboard to bypass the QR-Code scanner.
     private final static String LAYER_APP_ID = null;
-    private final static String LAYER_GCM_SENDER_ID = "748607264448";
+    private final static String GCM_SENDER_ID = "748607264448";
 
     private String mLayerAppId;
 
@@ -69,7 +69,7 @@ public class Flavor implements App.Flavor {
         String appId = getLayerAppId();
         if (appId == null) return null;
 
-        options.googleCloudMessagingSenderId(LAYER_GCM_SENDER_ID);
+        options.googleCloudMessagingSenderId(GCM_SENDER_ID);
         return LayerClient.newInstance(context, appId, options);
     }
 

--- a/app/src/providerrails/java/com/layer/messenger/flavor/Flavor.java
+++ b/app/src/providerrails/java/com/layer/messenger/flavor/Flavor.java
@@ -5,31 +5,33 @@ import android.content.Context;
 import com.layer.atlas.provider.ParticipantProvider;
 import com.layer.messenger.App;
 import com.layer.messenger.R;
+import com.layer.messenger.flavor.util.CustomEndpoint;
 import com.layer.messenger.util.AuthenticationProvider;
 import com.layer.messenger.util.Log;
 import com.layer.sdk.LayerClient;
 
 public class Flavor implements App.Flavor {
     // Set your Layer App ID from your Layer Developer Dashboard.
-    private final static String LAYER_APP_ID = null;
+    public final static String LAYER_APP_ID = null;
 
     // Set your Google Cloud Messaging Sender ID from your Google Developers Console. 
-    private final static String LAYER_GCM_SENDER_ID = null;
+    private final static String GCM_SENDER_ID = null;
 
     @Override
     public String getLayerAppId() {
-        return LAYER_APP_ID;
+        return (LAYER_APP_ID != null) ? LAYER_APP_ID : CustomEndpoint.getLayerAppId();
     }
 
     @Override
     public LayerClient generateLayerClient(Context context, LayerClient.Options options) {
-        if (LAYER_APP_ID == null) {
+        String layerAppId = getLayerAppId();
+        if (layerAppId == null) {
             if (Log.isLoggable(Log.ERROR)) Log.e(context.getString(R.string.app_id_required));
             return null;
         }
-
-        if (LAYER_GCM_SENDER_ID != null) options.googleCloudMessagingSenderId(LAYER_GCM_SENDER_ID);
-        return LayerClient.newInstance(context, LAYER_APP_ID, options);
+        if (GCM_SENDER_ID != null) options.googleCloudMessagingSenderId(GCM_SENDER_ID);
+        CustomEndpoint.setLayerClientOptions(options);
+        return LayerClient.newInstance(context, layerAppId, options);
     }
 
     @Override

--- a/app/src/providerrails/java/com/layer/messenger/flavor/RailsLoginActivity.java
+++ b/app/src/providerrails/java/com/layer/messenger/flavor/RailsLoginActivity.java
@@ -6,16 +6,19 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.KeyEvent;
+import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
+import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import com.layer.messenger.App;
-import com.layer.messenger.util.AuthenticationProvider;
 import com.layer.messenger.ConversationsListActivity;
-import com.layer.messenger.util.Log;
 import com.layer.messenger.R;
+import com.layer.messenger.flavor.util.CustomEndpoint;
+import com.layer.messenger.util.AuthenticationProvider;
+import com.layer.messenger.util.Log;
 
 public class RailsLoginActivity extends AppCompatActivity {
     EditText mEmail;
@@ -49,6 +52,15 @@ public class RailsLoginActivity extends AppCompatActivity {
                 return false;
             }
         });
+
+        // Optionally add a CustomEndpoint Spinner (not typical)
+        if (Flavor.LAYER_APP_ID == null) {
+            Spinner customEndpoints = CustomEndpoint.createSpinner(this);
+            if (customEndpoints != null) {
+                customEndpoints.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+                ((ViewGroup) mPassword.getParent()).addView(customEndpoints);
+            }
+        }
     }
 
     @Override

--- a/app/src/providerrails/java/com/layer/messenger/flavor/util/CustomEndpoint.java
+++ b/app/src/providerrails/java/com/layer/messenger/flavor/util/CustomEndpoint.java
@@ -1,0 +1,232 @@
+package com.layer.messenger.flavor.util;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
+
+import com.layer.messenger.App;
+import com.layer.messenger.util.Log;
+import com.layer.sdk.LayerClient;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * CustomEndpoint provides a mechanism for using endpoints besides the default Layer endpoints.
+ * This is only useful for enterprise customers with custom endpoints.  Contact support@layer.com
+ * for information.
+ *
+ * @see com.layer.sdk.LayerClient.Options#customEndpoint(String, String, String, String)
+ */
+public class CustomEndpoint {
+    private static Endpoint sEndpoint;
+    private static Map<String, Endpoint> sEndpoints;
+
+    public static String getLayerAppId() {
+        Endpoint endpoint = getEndpoint();
+        return endpoint == null ? null : endpoint.getAppId();
+    }
+
+    public static void setLayerClientOptions(LayerClient.Options options) {
+        Endpoint endpoint = getEndpoint();
+        if (endpoint != null) endpoint.setLayerClientOptions(options);
+    }
+
+    public static boolean hasEndpoints() {
+        Map<String, Endpoint> endpoints = getEndpoints();
+        return endpoints != null && !endpoints.isEmpty();
+    }
+
+    public static Spinner createSpinner(Context context) {
+        Set<String> endpointNames = getNames();
+        if (endpointNames == null || endpointNames.isEmpty()) return null;
+
+        List<String> namesList = new ArrayList<String>(endpointNames);
+        Collections.sort(namesList);
+        ArrayAdapter<String> adapter = new ArrayAdapter<String>(context, android.R.layout.simple_dropdown_item_1line, namesList);
+        Spinner spinner = new Spinner(context);
+        spinner.setAdapter(adapter);
+
+        Endpoint endpoint = getEndpoint();
+        if (endpoint != null) {
+            int position = namesList.indexOf(endpoint.getName());
+            if (position != -1) spinner.setSelection(position);
+        }
+        setEndpointName((String) spinner.getSelectedItem());
+
+        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                setEndpointName((String) parent.getSelectedItem());
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                setEndpointName(null);
+            }
+        });
+
+        return spinner;
+    }
+
+    private static Set<String> getNames() {
+        Map<String, Endpoint> endpoints = getEndpoints();
+        return endpoints == null ? null : endpoints.keySet();
+    }
+
+    private static void setEndpointName(String name) {
+        App.getInstance().getSharedPreferences("layer_custom_endpoint", Context.MODE_PRIVATE).edit().putString("name", name).commit();
+        Map<String, Endpoint> endpoints = getEndpoints();
+        sEndpoint = (endpoints == null) ? null : endpoints.get(name);
+        if (Log.isLoggable(Log.VERBOSE)) Log.v("Setting custom endpoint to: " + sEndpoint);
+    }
+
+    private static Endpoint getEndpoint() {
+        if (sEndpoint != null) return sEndpoint;
+        String savedEndpointName = App.getInstance().getSharedPreferences("layer_custom_endpoint", Context.MODE_PRIVATE).getString("name", null);
+        if (savedEndpointName == null) return null;
+        Map<String, Endpoint> endpoints = getEndpoints();
+        sEndpoint = (endpoints == null) ? null : endpoints.get(savedEndpointName);
+        return sEndpoint;
+    }
+
+    private static Map<String, Endpoint> getEndpoints() {
+        if (sEndpoints != null) return sEndpoints;
+        sEndpoints = new HashMap<String, Endpoint>();
+
+        // Check for endpoints in resources
+        Context context = App.getInstance();
+        int resId = context.getResources().getIdentifier("layer_endpoints", "raw", context.getPackageName());
+        if (resId == 0) return null;
+
+        // Read endpoints from resources
+        Writer writer = new StringWriter();
+        char[] buffer = new char[1024];
+        InputStream is = context.getResources().openRawResource(resId);
+        try {
+            Reader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            int n;
+            while ((n = reader.read(buffer)) != -1) {
+                writer.write(buffer, 0, n);
+            }
+        } catch (Exception e) {
+            if (Log.isLoggable(Log.ERROR)) Log.e(e.getMessage(), e);
+        } finally {
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    if (Log.isLoggable(Log.ERROR)) Log.e(e.getMessage(), e);
+                }
+            }
+        }
+        String content = writer.toString().trim();
+        if (content.isEmpty()) return null;
+
+        // Parse endpoints from JSON
+        try {
+            JSONArray array = new JSONArray(content);
+            for (int i = 0; i < array.length(); i++) {
+                Endpoint endpoint = new Endpoint(array.getJSONObject(i));
+                sEndpoints.put(endpoint.getName(), endpoint);
+            }
+            return sEndpoints;
+        } catch (JSONException e) {
+            if (Log.isLoggable(Log.ERROR)) Log.e(e.getMessage(), e);
+        }
+        return null;
+    }
+
+    public static class Endpoint {
+        final String mName;
+        final String mAppId;
+        final String mGcmSenderId;
+        final String mProviderUrl;
+
+        final String mPlatformUrl;
+        final String mPlatformToken;
+
+        final String mEndpointConf;
+        final String mEndpointCert;
+        final String mEndpointAuth;
+        final String mEndpointSync;
+
+        public Endpoint(JSONObject o) throws JSONException {
+            mName = o.getString("name");
+            mAppId = o.getString("appId");
+            mGcmSenderId = o.getString("gcmSenderId");
+            mProviderUrl = o.getString("providerUrl");
+
+            JSONObject platform = o.optJSONObject("platform");
+            if (platform != null) {
+                mPlatformUrl = platform.optString("url");
+                mPlatformToken = platform.optString("token");
+            } else {
+                mPlatformUrl = null;
+                mPlatformToken = null;
+            }
+
+            JSONObject endpoint = o.optJSONObject("endpoint");
+            if (endpoint != null) {
+                mEndpointConf = endpoint.getString("conf");
+                mEndpointCert = endpoint.getString("cert");
+                mEndpointAuth = endpoint.getString("auth");
+                mEndpointSync = endpoint.getString("sync");
+            } else {
+                mEndpointConf = null;
+                mEndpointCert = null;
+                mEndpointAuth = null;
+                mEndpointSync = null;
+            }
+        }
+
+        public void setLayerClientOptions(LayerClient.Options options) {
+            if (mGcmSenderId != null) options.googleCloudMessagingSenderId(mGcmSenderId);
+
+            if (mEndpointAuth != null) {
+                options.customEndpoint(mEndpointConf, mEndpointCert, mEndpointAuth, mEndpointSync);
+            }
+        }
+
+        public String getName() {
+            return mName;
+        }
+
+        public String getAppId() {
+            return mAppId;
+        }
+
+        @Override
+        public String toString() {
+            return "Endpoint{" +
+                    "mName='" + mName + '\'' +
+                    ", mAppId='" + mAppId + '\'' +
+                    ", mGcmSenderId='" + mGcmSenderId + '\'' +
+                    ", mProviderUrl='" + mProviderUrl + '\'' +
+                    ", mPlatformUrl='" + mPlatformUrl + '\'' +
+                    ", mPlatformToken='" + mPlatformToken + '\'' +
+                    ", mEndpointConf='" + mEndpointConf + '\'' +
+                    ", mEndpointCert='" + mEndpointCert + '\'' +
+                    ", mEndpointAuth='" + mEndpointAuth + '\'' +
+                    ", mEndpointSync='" + mEndpointSync + '\'' +
+                    '}';
+        }
+    }
+}

--- a/app/src/providerrails/res/values/strings.xml
+++ b/app/src/providerrails/res/values/strings.xml
@@ -3,7 +3,7 @@
 <resources>
     <string name="app_name">Atlas Messenger</string>
     <string name="app_id_required">Please set your Layer App ID in `Flavor.java` when using the Rails Identity Provider.  You can get your Layer App ID from the developer dashboard.</string>
-    
+
     <string name="login_email_hint">Email</string>
     <string name="login_password_hint">Password</string>
     <string name="login_dialog_message">Logging In&#8230;</string>


### PR DESCRIPTION
Rails provider's `CustomEndpoint` provides a mechanism for reading custom Layer endpoints from resources (`res/raw/layer_endpoints`), and generating a Spinner for selecting them.  A non-`null` `Flavor.LAYER_APP_ID` overrides `CustomEndpoint` and removes the Spinner.