### PR TITLE
Fix for resuming with provider credentials and not Layer credentials.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
         applicationId "com.layer.messenger"
         minSdkVersion 14
         targetSdkVersion 23
-        versionCode 18
+        versionCode 23
         versionName "$versionCode"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,9 +3,6 @@
     package="com.layer.messenger"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- QR Code, CameraSender -->
-    <uses-permission android:name="android.permission.CAMERA"/>
-
     <!-- GallerySender -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
@@ -63,6 +60,12 @@
         <!-- Activity: Individual Conversation settings -->
         <activity
             android:name=".ConversationSettingsActivity"
+            android:windowSoftInputMode="adjustResize">
+        </activity>
+
+        <!-- Activity: Resume using provider credentials -->
+        <activity
+            android:name=".ResumeActivity"
             android:windowSoftInputMode="adjustResize">
         </activity>
 

--- a/app/src/main/java/com/layer/messenger/ResumeActivity.java
+++ b/app/src/main/java/com/layer/messenger/ResumeActivity.java
@@ -1,0 +1,77 @@
+package com.layer.messenger;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+
+import com.layer.messenger.util.Log;
+import com.layer.sdk.LayerClient;
+import com.layer.sdk.exceptions.LayerException;
+import com.layer.sdk.listeners.LayerAuthenticationListener;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ResumeActivity extends AppCompatActivity implements LayerAuthenticationListener {
+    public static final String EXTRA_LOGGED_IN_ACTIVITY_CLASS_NAME = "loggedInActivity";
+    public static final String EXTRA_LOGGED_OUT_ACTIVITY_CLASS_NAME = "loggedOutActivity";
+
+    private AtomicReference<Class<? extends Activity>> mLoggedInActivity = new AtomicReference<Class<? extends Activity>>(null);
+    private AtomicReference<Class<? extends Activity>> mLoggedOutActivity = new AtomicReference<Class<? extends Activity>>(null);
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_resume);
+        final ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) actionBar.hide();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void onResume() {
+        super.onResume();
+        App.getLayerClient().registerAuthenticationListener(this).authenticate();
+        try {
+            mLoggedInActivity.set((Class<? extends Activity>) Class.forName(getIntent().getStringExtra(EXTRA_LOGGED_IN_ACTIVITY_CLASS_NAME)));
+            mLoggedOutActivity.set((Class<? extends Activity>) Class.forName(getIntent().getStringExtra(EXTRA_LOGGED_OUT_ACTIVITY_CLASS_NAME)));
+        } catch (ClassNotFoundException e) {
+            if (Log.isLoggable(Log.ERROR)) {
+                Log.e("Could not find class: " + e.getCause(), e);
+            }
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        App.getLayerClient().unregisterAuthenticationListener(this);
+        super.onPause();
+    }
+
+    @Override
+    public void onAuthenticated(LayerClient layerClient, String s) {
+        startActivity(mLoggedInActivity.get());
+    }
+
+    @Override
+    public void onDeauthenticated(LayerClient layerClient) {
+        startActivity(mLoggedOutActivity.get());
+    }
+
+    @Override
+    public void onAuthenticationChallenge(LayerClient layerClient, String s) {
+
+    }
+
+    @Override
+    public void onAuthenticationError(LayerClient layerClient, LayerException e) {
+        startActivity(mLoggedOutActivity.get());
+    }
+
+    private void startActivity(Class<? extends Activity> activityClass) {
+        Intent intent = new Intent(this, activityClass);
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
+    }
+}

--- a/app/src/main/java/com/layer/messenger/util/Log.java
+++ b/app/src/main/java/com/layer/messenger/util/Log.java
@@ -5,7 +5,7 @@ package com.layer.messenger.util;
  * `android.util.Log`. Logs are tagged with `Atlas`.
  */
 public class Log {
-    public static final String TAG = "AtlasMessenger";
+    public static final String TAG = "LayerAtlasMsgr";
 
     // Makes IDE auto-completion easy
     public static final int VERBOSE = android.util.Log.VERBOSE;

--- a/app/src/main/res/layout/activity_resume.xml
+++ b/app/src/main/res/layout/activity_resume.xml
@@ -1,0 +1,22 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_gravity="center"
+              android:orientation="vertical"
+              android:padding="16dp">
+
+    <ProgressBar
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/progressBar"
+        android:layout_gravity="center_horizontal"
+        android:indeterminate="true"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/alert_message_resuming"
+        android:id="@+id/textView"
+        android:layout_gravity="center_horizontal"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="title_settings">Settings</string>
     <string name="title_conversation_details">Details</string>
 
+    <string name="alert_message_resuming">Resuming Session</string>
+
     <string name="alert_message_logout">Log out?</string>
     <string name="alert_message_delete_message">Delete message?</string>
     <string name="alert_message_delete_conversation">Delete conversation?</string>

--- a/app/src/providerdemo/AndroidManifest.xml
+++ b/app/src/providerdemo/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.layer.messenger"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- QR Code -->
+    <!-- QR Code, CameraSender -->
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <application>

--- a/app/src/providerrails/java/com/layer/messenger/flavor/RailsAuthenticationProvider.java
+++ b/app/src/providerrails/java/com/layer/messenger/flavor/RailsAuthenticationProvider.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import android.widget.Toast;
 
 import com.layer.messenger.R;
+import com.layer.messenger.ResumeActivity;
 import com.layer.messenger.flavor.util.CustomEndpoint;
 import com.layer.messenger.util.AuthenticationProvider;
 import com.layer.messenger.util.Log;
@@ -16,11 +17,8 @@ import com.layer.sdk.exceptions.LayerException;
 import org.json.JSONObject;
 
 import java.io.BufferedInputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -94,10 +92,16 @@ public class RailsAuthenticationProvider implements AuthenticationProvider<Rails
         }
 
         if ((layerClient != null) && hasCredentials()) {
-            // With a LayerClient and cached provider credentials, we can authenticate here without routing required.
-            if (Log.isLoggable(Log.VERBOSE)) Log.v("Using cached credentials to resume");
-            layerClient.authenticate();
-            return false;
+            // With a LayerClient and cached provider credentials, we can resume.
+            if (Log.isLoggable(Log.VERBOSE)) {
+                Log.v("Routing to resume Activity using cached credentials");
+            }
+            Intent intent = new Intent(from, ResumeActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.putExtra(ResumeActivity.EXTRA_LOGGED_IN_ACTIVITY_CLASS_NAME, from.getClass().getName());
+            intent.putExtra(ResumeActivity.EXTRA_LOGGED_OUT_ACTIVITY_CLASS_NAME, RailsLoginActivity.class.getName());
+            from.startActivity(intent);
+            return true;
         }
 
         // We have a Layer App ID but no cached provider credentials: routing to Login required.
@@ -155,7 +159,7 @@ public class RailsAuthenticationProvider implements AuthenticationProvider<Rails
             if (credentials.getAuthToken() != null) {
                 connection.setRequestProperty("X_AUTH_TOKEN", credentials.getAuthToken());
             }
-            
+
             // Credentials
             JSONObject rootObject = new JSONObject();
             JSONObject userObject = new JSONObject();


### PR DESCRIPTION
Resuming with cached provider credentials but not cached Layer credentials used to return false from the authentication router, which created a race condition between authenticating and displaying conversation information in the ConversationsListActivity.

This change introduces a 3rd routing state, which uses a new `ResumeActivity` to display a progress spinner during background authentication with Layer.

This change also reduces the number of required permissions by excluding the unneeded CAMERA permission.