### PR TITLE
Fix circle ci failed build from fork

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,9 @@ checkout:
   post:
     - git submodule sync
     - git submodule update --init
-    - eval "$DUMMY_GOOGLE_SERVICES_JSON_CONFIG"
+  commands:
+    - mkdir -p ./app/src/debug/
+    - chmod 0755 ./generate-json.sh && ./generate-json.sh
 
 dependencies:
   pre:

--- a/generate-json.sh
+++ b/generate-json.sh
@@ -1,0 +1,69 @@
+echo '{
+        "project_info": {
+          "project_number": "dumdumdum-something",
+          "project_id": "dee-doo-dah-32"
+        },
+        "client": [
+          {
+            "client_info": {
+              "mobilesdk_app_id": "yeedleoooh:uh:uh",
+              "android_client_info": {
+                "package_name": "com.layer.messenger"
+              }
+            },
+            "oauth_client": [
+
+            ],
+            "api_key": [
+              {
+                "current_key": "laaaadeeeeedaaahhhdada"
+              }
+            ],
+            "services": {
+              "analytics_service": {
+                "status": 1
+              },
+              "appinvite_service": {
+                "status": 1,
+                "other_platform_oauth_client": [
+
+                ]
+              },
+              "ads_service": {
+                "status": 1
+              }
+            }
+          },
+          {
+            "client_info": {
+              "mobilesdk_app_id": "1:yodlee:oooo:ohoh",
+              "android_client_info": {
+                "package_name": "com.layer.sdkquickstart"
+              }
+            },
+            "oauth_client": [
+
+            ],
+            "api_key": [
+              {
+                "current_key": "llaaaaaa-deeee-doooo-dahdah"
+              }
+            ],
+            "services": {
+              "analytics_service": {
+                "status": 1
+              },
+              "appinvite_service": {
+                "status": 1,
+                "other_platform_oauth_client": [
+
+                ]
+              },
+              "ads_service": {
+                "status": 1
+              }
+            }
+          }
+        ],
+        "configuration_version": "1"
+      }' > ./app/google-services.json


### PR DESCRIPTION
When pr is sent from a fork, the environment variable DUMMY_GOOGLE_SERVICES_JSON_CONFIG is missing thereby causing the build to fail. This PR Creates dummy google-service.json when building app in circle ci.